### PR TITLE
Actualiza hora evento

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -28,7 +28,7 @@ links:
     url: https://www.youtube.com/@IndexGal
 
 events:
-  - time: 2024-04-25
+  - time: 2024-04-25T17:00:00Z
     title: WordPress dende dentro
     description: |
       André Maneiro traballa en Automattic como desenvolvedor de Gutenberg e WordPress. Nesta charla falaranos como é o seu día a día traballando nun proxecto tan grande e con tanto impacto.


### PR DESCRIPTION
Actualiza a hora do evento ás 19h, aka 17h UTC.

Agora mesmo está a unha hora intempestiva 😅 

<img width="627" alt="Captura de ecrã 2024-04-08, às 15 33 57" src="https://github.com/index-gal/index-gal/assets/583546/1a85f5c7-6147-4b0d-a433-18f7395f51de">
